### PR TITLE
Specify core option for core libries

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -5,7 +5,7 @@ MRuby::Gem::Specification.new('mruby-tempfile') do |spec|
   spec.add_dependency 'mruby-dir'
   #spec.add_dependency 'mruby-env'      # not mandatory
   spec.add_dependency 'mruby-io'
-  spec.add_dependency 'mruby-random'
-  spec.add_dependency 'mruby-sprintf'
-  spec.add_dependency 'mruby-time'
+  spec.add_dependency 'mruby-random', core: 'mruby-random'
+  spec.add_dependency 'mruby-sprintf', core: 'mruby-sprintf'
+  spec.add_dependency 'mruby-time', core: 'mruby-time'
 end


### PR DESCRIPTION
I got "mgem not found error" when building mruby 1.2.0 with mruby-tempfile.
I think we should specify `core: ...` for mrbgems added to core libraries and removed from mgem-list.