### PR TITLE
Respect cv-qualifier

### DIFF
--- a/src/tempfile.c
+++ b/src/tempfile.c
@@ -17,7 +17,7 @@
 static void mrb_tempfile_path_free(mrb_state *, void *);
 
 struct tempfile_path {
-  char *pathname;
+  const char *pathname;
 };
 
 const static struct mrb_data_type mrb_tempfile_path_type = { "TempfilePath", mrb_tempfile_path_free };


### PR DESCRIPTION
This fixes the following compiler warning.

src/tempfile.c:46:16: warning: assignment discards ‘const’ qualifier
from pointer target type [-Wdiscarded-qualifiers]