### PR TITLE
Dir.tmpdir: default to "/tmp" if none of the env vars is set

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -3,7 +3,7 @@ MRuby::Gem::Specification.new('mruby-tempfile') do |spec|
   spec.author  = 'Internet Initiative Japan Inc.'
 
   spec.add_dependency 'mruby-dir'
-  #spec.add_dependency 'mruby-env'      # not mandatory
+  spec.add_dependency 'mruby-env'
   spec.add_dependency 'mruby-io'
   spec.add_dependency 'mruby-random', core: 'mruby-random'
   spec.add_dependency 'mruby-sprintf', core: 'mruby-sprintf'

--- a/mrblib/tmpdir.rb
+++ b/mrblib/tmpdir.rb
@@ -4,9 +4,8 @@ class Dir
   end
 
   def self.tmpdir
-    tmpdir = "/tmp" || ENV['TMPDIR'] || ENV['TMP'] || ENV['TEMP'] || ENV['USERPROFILE']
+    tmpdir = ENV['TMPDIR'] || ENV['TMP'] || ENV['TEMP'] || ENV['USERPROFILE'] || "/tmp"
 
     tmpdir
   end
 end
-

--- a/test/test_tempfile.rb
+++ b/test/test_tempfile.rb
@@ -16,3 +16,10 @@ assert('Tempfile remove tempfile (call Tempfile#close with real = true)') do
   t.close true
   assert_false File.exist?(path)
 end
+
+assert('Dir.tmpdir reacts to ENV changes') do
+  ["TMPDIR", "TMP", "TEMP", "USERPROFILE"].each { |d| ENV.delete(d) }
+  assert_equal "/tmp", Dir.tmpdir
+  ENV["TMPDIR"] = "/some/where"
+  assert_equal "/some/where", Dir.tmpdir
+end


### PR DESCRIPTION
Dir.tmpdir used to always return `"/tmp"` without ever consulting the environment. This fixes that.