### PR TITLE
Clear (delete) "TMPDIR" environment variables after testing

### DIFF
--- a/test/test_tempfile.rb
+++ b/test/test_tempfile.rb
@@ -22,4 +22,5 @@ assert('Dir.tmpdir reacts to ENV changes') do
   assert_equal "/tmp", Dir.tmpdir
   ENV["TMPDIR"] = "/some/where"
   assert_equal "/some/where", Dir.tmpdir
+  ENV.delete "TMPDIR"
 end


### PR DESCRIPTION
When I test my mgem bundling mruby-tempfile, a test is broken because ENV["TMPDIR"] was set to "/some/where".