### PR TITLE
In mruby 2.0.0, use __to_str instead of to_str

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -4,7 +4,7 @@ MRuby::Gem::Specification.new('mruby-tempfile') do |spec|
 
   spec.add_dependency 'mruby-dir'
   spec.add_dependency 'mruby-env'
-  spec.add_dependency 'mruby-io'
+  spec.add_dependency 'mruby-io', core: 'mruby-io'
   spec.add_dependency 'mruby-random', core: 'mruby-random'
   spec.add_dependency 'mruby-sprintf', core: 'mruby-sprintf'
   spec.add_dependency 'mruby-time', core: 'mruby-time'

--- a/mrblib/tmpdir.rb
+++ b/mrblib/tmpdir.rb
@@ -9,14 +9,14 @@ class Dir
     tmpdir ||= tmpdir()
 
     prefix, suffix = (prefix_suffix || 'd')
-    if ! prefix.respond_to?(:to_str)
+    if ! prefix.respond_to?(:__to_str)
       raise ArgumentError, "unexpected prefix: #{prefix.inspect}"
     end
-    prefix = prefix.to_str
-    if suffix && ! suffix.respond_to?(:to_str)
+    prefix = prefix.__to_str
+    if suffix && ! suffix.respond_to?(:__to_str)
       raise ArgumentError, "unexpected suffix: #{suffix.inspect}"
     end
-    suffix = suffix.to_str if suffix
+    suffix = suffix.__to_str if suffix
     [prefix, suffix].each {|fix|
       [File::SEPARATOR, File::ALT_SEPARATOR].each {|sep|
         fix.gsub!(sep, '') if fix && sep

--- a/mrblib/tmpdir.rb
+++ b/mrblib/tmpdir.rb
@@ -9,14 +9,24 @@ class Dir
     tmpdir ||= tmpdir()
 
     prefix, suffix = (prefix_suffix || 'd')
-    if ! prefix.respond_to?(:__to_str)
+    if ! (prefix.respond_to?(:to_str) && prefix.respond_to?(:__to_str))
       raise ArgumentError, "unexpected prefix: #{prefix.inspect}"
     end
-    prefix = prefix.__to_str
-    if suffix && ! suffix.respond_to?(:__to_str)
+    begin
+      prefix = prefix.__to_str
+    rescue
+      prefix = prefix.to_str
+    end
+    if suffix && ! (suffix.respond_to?(:to_str) && suffix.respond_to?(:__to_str))
       raise ArgumentError, "unexpected suffix: #{suffix.inspect}"
     end
-    suffix = suffix.__to_str if suffix
+    if suffix
+      begin
+        suffix = suffix.__to_str
+      rescue
+        suffix = suffix.to_str
+      end
+    end
     [prefix, suffix].each {|fix|
       [File::SEPARATOR, File::ALT_SEPARATOR].each {|sep|
         fix.gsub!(sep, '') if fix && sep

--- a/mrblib/tmpdir.rb
+++ b/mrblib/tmpdir.rb
@@ -9,7 +9,7 @@ class Dir
     tmpdir ||= tmpdir()
 
     prefix, suffix = (prefix_suffix || 'd')
-    if ! (prefix.respond_to?(:to_str) && prefix.respond_to?(:__to_str))
+    if ! (prefix.respond_to?(:to_str) || prefix.respond_to?(:__to_str))
       raise ArgumentError, "unexpected prefix: #{prefix.inspect}"
     end
     begin
@@ -17,7 +17,7 @@ class Dir
     rescue
       prefix = prefix.to_str
     end
-    if suffix && ! (suffix.respond_to?(:to_str) && suffix.respond_to?(:__to_str))
+    if suffix && ! (suffix.respond_to?(:to_str) || suffix.respond_to?(:__to_str))
       raise ArgumentError, "unexpected suffix: #{suffix.inspect}"
     end
     if suffix

--- a/run_test.rb
+++ b/run_test.rb
@@ -25,7 +25,6 @@ MRuby::Build.new do |conf|
 
   conf.gem github: 'iij/mruby-dir'
   conf.gem github: 'iij/mruby-env'
-  conf.gem github: 'iij/mruby-io'
 
   conf.gem File.expand_path(File.dirname(__FILE__))
 


### PR DESCRIPTION
ref: https://github.com/mruby/mruby/commit/ff08856fe314faa4d16b4502c0960a3475387846

*This commit breaks the compatibility for mruby under 2.0.0.