### PR TITLE
fix CI

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -4,7 +4,7 @@ MRuby::Gem::Specification.new('mruby-tempfile') do |spec|
 
   spec.add_dependency 'mruby-dir'
   spec.add_dependency 'mruby-env'
-  spec.add_dependency 'mruby-io'
+  spec.add_dependency 'mruby-io', core: 'mruby-io'
   spec.add_dependency 'mruby-random', core: 'mruby-random'
   spec.add_dependency 'mruby-sprintf', core: 'mruby-sprintf'
   spec.add_dependency 'mruby-time', core: 'mruby-time'

--- a/run_test.rb
+++ b/run_test.rb
@@ -23,10 +23,6 @@ MRuby::Build.new do |conf|
   toolchain :gcc
   conf.gembox 'default'
 
-  conf.gem github: 'iij/mruby-dir'
-  conf.gem github: 'iij/mruby-env'
-  conf.gem github: 'iij/mruby-io'
-
   conf.gem File.expand_path(File.dirname(__FILE__))
 
   conf.enable_test


### PR DESCRIPTION
mruby-io was merged into mruby core and iij/mruby-io is not compatible with mruby:master now.  hinted by https://github.com/iij/mruby-tempfile/pull/12.