### PR TITLE
Add support for musl libc

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -9,4 +9,8 @@ MRuby::Gem::Specification.new('mruby-tempfile') do |spec|
   spec.add_dependency 'mruby-sprintf', core: 'mruby-sprintf'
   spec.add_dependency 'mruby-time', core: 'mruby-time'
   spec.add_dependency 'mruby-errno'
+
+  if spec.build.cc.command.include?('musl')
+    spec.linker.libraries << 'fts'
+  end
 end


### PR DESCRIPTION
Since fts (3) is not implemented in musl libc, it is necessary to link the following musl-fts library.

https://github.com/pullmoll/musl-fts