### PR TITLE
Remove an unused variable

### DIFF
--- a/mrblib/tempfile.rb
+++ b/mrblib/tempfile.rb
@@ -13,7 +13,6 @@ class Tempfile < File
   end
 
   def make_tmpname(basename, tempdir, n=nil)
-    rand_max = 0x100000000
     t = Time.now
     ymd = sprintf("%04d%02d%02d", t.year, t.month, t.day)
     pid = Tempfile._getpid


### PR DESCRIPTION
This variable is causing a cross-compilation failure on mruby 3, which is a bug of mruby, but it's useful to fix for testing others.