### PR TITLE
fix: Tempfile.close - call super() with no args

### DIFF
--- a/mrblib/tempfile.rb
+++ b/mrblib/tempfile.rb
@@ -48,7 +48,7 @@ class Tempfile < File
   end
 
   def close(real=false)
-    super
+    super()
     delete if real
 
     nil


### PR DESCRIPTION
I had tests failing on Tempfile.close(true). This patch fixed it.

Cheers, Srdjan